### PR TITLE
Enable manual input when no CRS found in XML

### DIFF
--- a/GRD_Loader.py
+++ b/GRD_Loader.py
@@ -219,8 +219,12 @@ class GrdLoader:
             if(os.path.exists(file_path+'.xml')):
                 epsg=extract_proj_str(file_path+'.xml')
                 if(epsg== None):
-                    epsg=4326
-                    self.iface.messageBar().pushMessage("No CRS found in XML, default to 4326", level=Qgis.Warning, duration=15)
+                    if not self.dlg.lineEdit_2.text():
+                        epsg=4326
+                        self.iface.messageBar().pushMessage("No CRS found in XML, default to 4326", level=Qgis.Warning, duration=15)
+                    else:
+                        epsg = int(self.dlg.lineEdit_2.text())
+                        self.iface.messageBar().pushMessage("CRS Read from manual input as "+str(epsg)+"", level=Qgis.Warning, duration=15)
                 else:
                     self.iface.messageBar().pushMessage("CRS Read from XML as "+epsg+", manual input ignored", level=Qgis.Info, duration=15)
             else:


### PR DESCRIPTION
In some cases, the EPSG is not defined in Oasis Montaj. For example, no Antarctic Polar Stereographic projection is available in Oasis Montaj. In that case, we should make manual input EPSG works.

The actual projection looks like this..						<gco:CharacterString>PROJCS["ADMAP",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_84",6378137,298.257223563002]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199432955]],PROJECTION["Stereographic"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],PARAMETER["Scale_Factor",1],PARAMETER["Latitude_Of_Origin",-90],UNIT["Meter",1]]</gco:CharacterString>
